### PR TITLE
Set code type on readme.md examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Node.js Redsys api implementation with new the key-hashed message authentication
 
 ### Obtain signature and merchant parameters
 
-`````
+```js
 const Redsys = require('node-redsys-api').Redsys;
 
 function createPayment(description, total, titular, orderId, paymentId) {
@@ -29,11 +29,11 @@ function createPayment(description, total, titular, orderId, paymentId) {
 
   return { signature: redsys.createMerchantSignature(TPVConfig.secret, mParams), merchantParameters: redsys.createMerchantParameters(mParams), raw: mParams };
 }
-`````
+```
 
 ### Process TPV callback
 
-`````
+```js
 const merchantParams = response.Ds_MerchantParameters || response.DS_MERCHANTPARAMETERS;
 const signature = response.Ds_Signature || response.DS_SIGNATURE;
 
@@ -48,7 +48,7 @@ if (redsys.merchantSignatureIsValid(signature, merchantSignatureNotif) && dsResp
 /* 'TPV payment is KO;
 ... */
 }
-`````
+```
 
 ## Tests
 	


### PR DESCRIPTION
Set the type of code in the examples to Javascript so that readme.md is rendered with fully colored examples.

# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->
I wanted the examples to be more readable, so I added the markdown annotations needed by the markdown editor to render the code in the examples with colors instead of all-white.