### PR TITLE
fix: add support for numeric merchant orders

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,8 @@
 function zeroPad(buf, blocksize) {
   if (typeof buf === 'string') {
     buf = Buffer.from(buf, 'utf8');
+  } else {
+    buf = Buffer.from(buf.toString(), 'utf8')
   }
   var pad = Buffer.alloc((blocksize - (buf.length % blocksize)) % blocksize, 0);
   return Buffer.concat([buf, pad]);

--- a/test/api-redsys.js
+++ b/test/api-redsys.js
@@ -23,6 +23,11 @@ describe('Node Redsys API tests', () => {
       expect(this.redsys.decrypt3DES(encryptedText, settings.key))
         .to.be.equals(requestParams.DS_MERCHANT_ORDER);
     });
+    it('Encrypt Merchant order does not crash when order is a number', function() {
+      const merchantOrder = 1;
+      expect(this.redsys.encrypt3DES(merchantOrder, settings.key))
+        .to.be.equals(encryptedText);
+    })
   });
 
   describe('SHA256 algorithm', () => {


### PR DESCRIPTION
non-string merchant orders caused encryption to fail due to accessing `.length` on a non-string variable

# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
When merchant order is a number, app tried to access `buf.length`, causing the app to crash. With this change, when `buf` is not a string, it is converted to one before using it.
<!-- Describe Your PR Here! -->